### PR TITLE
uboot-pistachio: avoid version clash

### DIFF
--- a/uboot-pistachio/Makefile
+++ b/uboot-pistachio/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=u-boot
 PKG_RELEASE:=1
-PKG_VERSION=2015.10
+PKG_VERSION=2015.10-pistachio
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2


### PR DESCRIPTION
The package uboot-envtools also downloads a tar of u-boot-2015.10
but that is the official one rather than our pistachio version.
This then causes a race condition to see who dowloads theirs first
meaning the other package will attempt to build the wrong code.

Fixed by namespacing the custom uboot version dl.

Signed-off-by: Ian Pozella <Ian.Pozella@imgtec.com>