### PR TITLE
Jenkinsfile: set default for params

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,14 +1,16 @@
 #!/usr/bin/env groovy
 
+def DEFAULT_OPENWRT_BRANCH = 'ci40'
+
 properties([
     parameters([
-        string(defaultValue: 'ci40', description: 'OpenWrt branch to test against', \
+        string(defaultValue: DEFAULT_OPENWRT_BRANCH, description: 'OpenWrt branch to test against',
             name: "OPENWRT_BRANCH")
     ])
 ])
 
 stage('Trigger openwrt build') {
-    build job: "../openwrt/${OPENWRT_BRANCH}", parameters: [
+    build job: "../openwrt/${OPENWRT_BRANCH ?: DEFAULT_OPENWRT_BRANCH}", parameters: [
         string(name: 'OVERRIDE_CI40-PLATFORM-FEED', value: "${BRANCH_NAME}")
     ]
 }


### PR DESCRIPTION
Builds are configured (including parameters) from the Jenkinsfile.
This means the very first build doesn't have params and therefore
they don't get their defaults set either.

This is only an issue on the very first build of a job but the
organisation plugin adds PR's as new jobs meaning the first build
of every PR fails.

Hence check the param even exists before using it and if not use
it's default.

Signed-off-by: Ian Pozella <Ian.Pozella@imgtec.com>