### PR TITLE
Jenkinsfile: use params via their map

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,13 +2,12 @@
 
 properties([
     parameters([
-        string(defaultValue: 'ci40', description: 'OpenWrt branch to test against', \
+        string(defaultValue: 'ci40', description: 'OpenWrt branch to test against',
             name: "OPENWRT_BRANCH")
     ])
 ])
 
 stage('Trigger openwrt build') {
-    build job: "../openwrt/${OPENWRT_BRANCH}", parameters: [
-        string(name: 'OVERRIDE_CI40-PLATFORM-FEED', value: "${BRANCH_NAME}")
-    ]
+    build job: "../openwrt/${params.OPENWRT_BRANCH}",
+        parameters: [string(name: 'OVERRIDE_CI40-PLATFORM-FEED', value: "${BRANCH_NAME}")]
 }


### PR DESCRIPTION
Params are also set as top level variables but not on the first
build. Use the params via the map 'params' which is always set
even on the first build.

Signed-off-by: Ian Pozella <Ian.Pozella@imgtec.com>