### PR TITLE
Issue 294 : uccp420wlan: add patch to fix errors-warnings-while-compiling-against-kmod-mac80211

### DIFF
--- a/uccp420wlan/Makefile
+++ b/uccp420wlan/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=uccp420wlan
-PKG_VERSION:=6.9
+PKG_VERSION:=6.9.1
 PKG_RELEASE=1
 
 PKG_LICENSE:=GPL-2.0+

--- a/uccp420wlan/patches/0001-Fix-errors-warnings-while-compiling-against-kmod-mac.patch
+++ b/uccp420wlan/patches/0001-Fix-errors-warnings-while-compiling-against-kmod-mac.patch
@@ -1,0 +1,90 @@
+From e62baef655898526c69250bc63723241f3f4c46d Mon Sep 17 00:00:00 2001
+From: Francois Berder <francois.berder@imgtec.com>
+Date: Wed, 19 Oct 2016 15:31:21 +0100
+Subject: Fix errors/warnings while compiling against kmod-mac80211
+
+---
+ src/80211_if.c | 28 +++++++++++++---------------
+ 1 file changed, 13 insertions(+), 15 deletions(-)
+
+diff --git a/src/80211_if.c b/src/80211_if.c
+index 5ce61b7..6291194 100644
+--- a/src/80211_if.c
++++ b/src/80211_if.c
+@@ -1467,9 +1467,7 @@ static void init_hw(struct ieee80211_hw *hw)
+ 
+ static int ampdu_action(struct ieee80211_hw *hw,
+ 				struct ieee80211_vif *vif,
+-				enum ieee80211_ampdu_mlme_action action,
+-				struct ieee80211_sta *sta,
+-				u16 tid, u16 *ssn, u8 buf_size, bool amsdu)
++				struct ieee80211_ampdu_params *params)
+ {
+ 	int ret = 0;
+ 	unsigned int val = 0;
+@@ -1478,14 +1476,14 @@ static int ampdu_action(struct ieee80211_hw *hw,
+ 	UCCP_DEBUG_80211IF("%s-80211IF: ampdu action started\n",
+ 			((struct mac80211_dev *)(hw->priv))->name);
+ 		/* TODO */
+-	switch (action) {
++	switch (params->action) {
+ 	case IEEE80211_AMPDU_RX_START:
+ 		{
+-		val = tid | TID_INITIATOR_AP;
++		val = params->tid | TID_INITIATOR_AP;
+ 		dev->tid_info[val].tid_state = TID_STATE_AGGR_START;
+-		dev->tid_info[val].ssn = *ssn;
++		dev->tid_info[val].ssn = params->ssn;
+ 		uccp420wlan_prog_ba_session_data(1,
+-						 tid,
++						 params->tid,
+ 						 &dev->tid_info[val].ssn,
+ 						 1,
+ 						 vif->addr,
+@@ -1494,10 +1492,10 @@ static int ampdu_action(struct ieee80211_hw *hw,
+ 		break;
+ 	case IEEE80211_AMPDU_RX_STOP:
+ 		{
+-		val = tid | TID_INITIATOR_AP;
++		val = params->tid | TID_INITIATOR_AP;
+ 		dev->tid_info[val].tid_state = TID_STATE_AGGR_STOP;
+ 		uccp420wlan_prog_ba_session_data(0,
+-						 tid,
++						 params->tid,
+ 						 &dev->tid_info[val].ssn,
+ 						 1,
+ 						 vif->addr,
+@@ -1506,24 +1504,24 @@ static int ampdu_action(struct ieee80211_hw *hw,
+ 		break;
+ 	case IEEE80211_AMPDU_TX_START:
+ 		{
+-		val = tid | TID_INITIATOR_STA;
+-		ieee80211_start_tx_ba_cb_irqsafe(vif, sta->addr, tid);
++		val = params->tid | TID_INITIATOR_STA;
++		ieee80211_start_tx_ba_cb_irqsafe(vif, params->sta->addr, params->tid);
+ 		dev->tid_info[val].tid_state = TID_STATE_AGGR_START;
+-		dev->tid_info[val].ssn = *ssn;
++		dev->tid_info[val].ssn = params->ssn;
+ 		}
+ 		break;
+ 	case IEEE80211_AMPDU_TX_STOP_FLUSH:
+ 	case IEEE80211_AMPDU_TX_STOP_FLUSH_CONT:
+ 	case IEEE80211_AMPDU_TX_STOP_CONT:
+ 		{
+-		val = tid | TID_INITIATOR_STA;
++		val = params->tid | TID_INITIATOR_STA;
+ 		dev->tid_info[val].tid_state = TID_STATE_AGGR_STOP;
+-		ieee80211_stop_tx_ba_cb_irqsafe(vif, sta->addr, tid);
++		ieee80211_stop_tx_ba_cb_irqsafe(vif, params->sta->addr, params->tid);
+ 		}
+ 		break;
+ 	case IEEE80211_AMPDU_TX_OPERATIONAL:
+ 		{
+-		val = tid | TID_INITIATOR_STA;
++		val = params->tid | TID_INITIATOR_STA;
+ 		dev->tid_info[val].tid_state = TID_STATE_AGGR_OPERATIONAL;
+ 		}
+ 		break;
+-- 
+2.6.2
+


### PR DESCRIPTION
https://github.com/CreatorDev/uccp420wlan/pull/19 has reverted the patch to fix the errors and warnings , since it was specific to openwrt and uccp420wlan is being used for multiple distributinos such as buildroot too. So Added that patch in uccp420wlan package

This fixes CreatorDev/openwrt#294

Updated the feeds makefile to use the latest R6.9.1 release from CreatorDev/uccp420wlan repo
 